### PR TITLE
Update pytz version on requirements to the current version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tabulate==0.8.2
-pytz==2018.7
+pytz==2019.3
 peewee==2.10.2
 peewee-async==0.5.12
 croniter==0.3.29


### PR DESCRIPTION
Update pytz version on requirements to the current version due to daylight saving time in brazil being discontinued.