### PR TITLE
MONIT-196: Add alembic on requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.4-alpine
+FROM python:3.8-alpine
 
 LABEL maintainer="pagarme"
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -6,7 +6,8 @@ apk add --no-cache --virtual build-dependencies \
     gcc \
     python3-dev \
     musl-dev \
-    make
+    make \
+    g++
 # Install and keep psycopg2 dependency
 apk add postgresql-dev
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ sanic==0.8.3
 sanic-cors==0.9.7
 Sanic-Plugins-Framework==0.7.0
 async_lru==1.0.1
+python-json-logger==0.1.11
+alembic==1.6.2


### PR DESCRIPTION
- Change from python:3.6-alpine to python:3.8-alpine
- Add g++
- Add alembic