### PR TITLE
Hotfix tag 2021-05-25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.6.4-alpine
 
 LABEL maintainer="pagarme"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ croniter==0.3.29
 asyncpg>=0.18.2
 aiohttp==3.5.0
 aiopg==0.16.0
-sanic==0.8.3
+sanic==18.12.0
 sanic-cors==0.9.7
 Sanic-Plugins-Framework==0.7.0
 async_lru==1.0.1
 python-json-logger==0.1.11
-alembic==1.6.2
+alembic==1.5.0


### PR DESCRIPTION
- Rollback to python 3.6.4 due to errors cause on upgrade to python 3.8